### PR TITLE
Making echo a bit more reliable with newlines.

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -78,4 +78,4 @@ completion+="\n}"
 completion+="\n"
 completion+="\ncomplete -o default -F _sfdx sfdx"
 
-echo "$completion" > sfdx.bash
+echo -e "$completion" > sfdx.bash

--- a/sfdx.bash
+++ b/sfdx.bash
@@ -70,6 +70,7 @@ _sfdx()
         force:lightning:component:create \ 
         force:lightning:event:create \ 
         force:lightning:interface:create \ 
+        force:lightning:lint \ 
         force:lightning:test:create \ 
         force:lightning:test:install \ 
         force:lightning:test:run \ 


### PR DESCRIPTION
Echo is inconsistent across different versions of bash. In some versions, the newline character is printed. -e helps correctly interpret them.