### PR TITLE
Fix Error on install: -bash: -e: command not found

### DIFF
--- a/sfdx.bash
+++ b/sfdx.bash
@@ -1,4 +1,4 @@
--e #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # DESCRIPTION: Bash completion script for the Salesforce CLI
 # AUTHOR: Wade Wegner (@WadeWegner)


### PR DESCRIPTION
Fixes #5

Before merging though, i do think it's good to know why in the first place the `-e` option was added. So we are sure there is nothing breaking with this fix.